### PR TITLE
Make it more obvious that webchat users are guests

### DIFF
--- a/irc/fullscreen/index.md
+++ b/irc/fullscreen/index.md
@@ -2,5 +2,5 @@
 layout: minimal
 title:  IRC Web Chat — PHP-FIG
 ---
-<iframe src="http://webchat.freenode.net?nick=fig...&amp;channels=phpfig&amp;prompt=1"
+<iframe src="http://webchat.freenode.net?nick=fig_guest...&amp;channels=phpfig&amp;prompt=1"
 	style="border: 0; position:fixed; top:0; left:0; right:0; bottom:0; width:100%; height:100%"></iframe>


### PR DESCRIPTION
Currently, people join the irc all the time asking php questions under the name `fig123` leading people to believe that it's a single person asking hit and run questions :P

This changes the guest names to `fig_guest123`.