### PR TITLE
html-proofer was complaing about the league's SSL

### DIFF
--- a/index.md
+++ b/index.md
@@ -125,7 +125,7 @@ Do not combine separate membership requests in a single thread; one request per 
     </li>
 
     <li>
-        <h4><a target="_blank" href="https://thephpleague.com">The League of Extraordinary Packages</a></h4>
+        <h4><a target="_blank" href="http://thephpleague.com">The League of Extraordinary Packages</a></h4>
         Kayla Daniels (<a href="https://twitter.com/kayladnls">@kayladnls</a>)
     </li>
 


### PR DESCRIPTION
Not sure why html-proofer was being so picky about the league's ssl stuff but this should get the build green again.