### PR TITLE
Add redcardpet with_toc_data extension for HTML anchors

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,7 +6,7 @@ permalink:   /news/:title/
 exclude:     [vendor]
 markdown:    redcarpet
 redcarpet:
-  extensions: [tables]
+  extensions: [tables, with_toc_data]
 gems:
   - jekyll-redirect-from
 


### PR DESCRIPTION
As noted in request #143 this patch adds HTML anchors.