### PR TITLE
Fix/changed table scroll to auto

### DIFF
--- a/_sass/blocks/markdown.scss
+++ b/_sass/blocks/markdown.scss
@@ -108,7 +108,7 @@
     }
 
     .responsive-table {
-        overflow: scroll;
+        overflow: auto;
     }
 
     dt {


### PR DESCRIPTION
This PR

- [ ] changed the default responsive table scroll behavior to ``auto``

Before:
![before](https://cloud.githubusercontent.com/assets/2622534/10757792/4f97d49c-7cad-11e5-9ed0-fdffea38f91b.png)

Before (Responsive):
![before-responsive](https://cloud.githubusercontent.com/assets/2622534/10757818/86ed9f9e-7cad-11e5-97a8-b1b769cfd44b.png)

After:
![after](https://cloud.githubusercontent.com/assets/2622534/10757793/5355f3a2-7cad-11e5-97b7-c6bf66216fa1.png)

After (Responsive)
![after-responsive](https://cloud.githubusercontent.com/assets/2622534/10757796/5a4002fc-7cad-11e5-80ab-12545d884659.png)

