### PR TITLE
overflow: auto for code blocks

### DIFF
--- a/_sass/blocks/markdown.scss
+++ b/_sass/blocks/markdown.scss
@@ -200,7 +200,7 @@
 
     .highlight {
         padding: 10px 0 15px 15px;
-        overflow: scroll;
+        overflow: auto;
 
         line-height: 1.5;
 


### PR DESCRIPTION
Same as #166, but for code blocks.