### PR TITLE
Incorrect link to Guzzle website

### DIFF
--- a/pages/members.html
+++ b/pages/members.html
@@ -78,7 +78,7 @@ permalink: members/
             <td>Andre Romcke (<a href="http://twitter.com/andrerom/">@andrerom</a>)</td>
         </tr>
         <tr>
-            <td><a target="_blank" href="http://www.guzzlephp.com/">Guzzle</a></td>
+            <td><a target="_blank" href="http://guzzlephp.org/">Guzzle</a></td>
             <td>Jeremy Lindblom (<a href="https://twitter.com/jeremeamia/">@jeremeamia</a>)</td>
         </tr>
         <tr>


### PR DESCRIPTION
Changed to http://guzzlephp.org/ as seen on https://github.com/guzzle/guzzle