### PR TITLE
fallback code font to monospace

### DIFF
--- a/_sass/blocks/home_features.scss
+++ b/_sass/blocks/home_features.scss
@@ -102,7 +102,7 @@
         padding: 25px;
         min-height: 200px;
 
-        font-family: 'Source Code Pro';
+        font-family: 'Source Code Pro', monospace;
         font-size: 15px;
         line-height: 1.3;
 

--- a/_sass/blocks/markdown.scss
+++ b/_sass/blocks/markdown.scss
@@ -221,7 +221,7 @@
     code {
         padding: 3px 5px;
 
-        font-family: 'Source Code Pro';
+        font-family: 'Source Code Pro', monospace;
         font-size: 16px;
         letter-spacing: -0.02em;
 


### PR DESCRIPTION
Currently looks bad if the Source Code Pro font fails to load for whatever reason

![screen shot 2016-01-11 at 16 45 40](https://cloud.githubusercontent.com/assets/2760420/12249012/c4c0ba98-b882-11e5-923a-cc36a2730708.png)
