### PR TITLE
Add secretaries to members page

### DIFF
--- a/pages/members.html
+++ b/pages/members.html
@@ -216,4 +216,22 @@ permalink: members/
     </table>
     <h2>Why are there non-frameworks members?</h2>
     <p>It was quickly discovered that CMS, applications, package developers, etc. have as much to add as the frameworks themselves. The idea is to get a cross-section of the ecosystem and not JUST one specific group of developers. Having the implementors working alongside the people creating packages and the people developing systems with the frameworks are all of equal importance.</p>
+    <h2 class="table_title">Current Secretaries</h2>
+    <table>
+        <tr>
+            <th>Secretary</th>
+            <th>Term</th>
+        </tr>
+        <tr>
+            <td>Michael Cullum (<a href="https://twitter.com/michaelcullumuk">@michaelcullumuk</a>)</td>
+            <td>January 31st, 2016 - January 2018</td>
+        </tr>
+        <tr>
+            <td>Joe Ferguson (<a href="https://twitter.com/michaelcullumuk">@joepferguson</a>)</td>
+            <td>January 31st, 2016 - April 2017</td>
+        </tr>
+        <tr>
+            <td>Samantha Quiñones (<a href="https://twitter.com/michaelcullumuk">@ieatkillerbees</a>)</td>
+            <td>February 28th, 2016 - August 2016</td>
+        </tr>
 </div>

--- a/pages/members.html
+++ b/pages/members.html
@@ -217,6 +217,7 @@ permalink: members/
     <h2>Why are there non-frameworks members?</h2>
     <p>It was quickly discovered that CMS, applications, package developers, etc. have as much to add as the frameworks themselves. The idea is to get a cross-section of the ecosystem and not JUST one specific group of developers. Having the implementors working alongside the people creating packages and the people developing systems with the frameworks are all of equal importance.</p>
     <h2 class="table_title">Current Secretaries</h2>
+    <p>Feel free to contact the secretaries at info AT php-fig.org</p>
     <table>
         <tr>
             <th>Secretary</th>
@@ -227,11 +228,11 @@ permalink: members/
             <td>January 31st, 2016 - January 2018</td>
         </tr>
         <tr>
-            <td>Joe Ferguson (<a href="https://twitter.com/michaelcullumuk">@joepferguson</a>)</td>
+            <td>Joe Ferguson (<a href="https://twitter.com/joepferguson">@joepferguson</a>)</td>
             <td>January 31st, 2016 - April 2017</td>
         </tr>
         <tr>
-            <td>Samantha Quiñones (<a href="https://twitter.com/michaelcullumuk">@ieatkillerbees</a>)</td>
+            <td>Samantha Quiñones (<a href="https://twitter.com/ieatkillerbees">@ieatkillerbees</a>)</td>
             <td>February 28th, 2016 - August 2016</td>
         </tr>
 </div>


### PR DESCRIPTION
First pass at adding the 3 secretaries to the member page.

I'm unable to test this locally because I kept running into issues with ruby / json version 1.8.1 gem / ultimately getting stuck at "forbidden" errors trying to view http://0.0.0.0:4000. So I would appreciate someone who can run this locally.

So far just added our names, twitter, and term start / end dates.