### PR TITLE
Fix link href to bylaws page.

### DIFF
--- a/pages/members.html
+++ b/pages/members.html
@@ -46,7 +46,7 @@ permalink: members/
             <td>February 28th, 2016 - August 2016</td>
         </tr>
     </table>
-    <p>Feel free to contact the secretaries at info AT php-fig.org. For more information on the secretaries' role, see the <a href="bylaws/membership/#fig-secretary">bylaws</a>.</p>
+    <p>Feel free to contact the secretaries at info AT php-fig.org. For more information on the secretaries' role, see the <a href="/bylaws/membership/#fig-secretary">bylaws</a>.</p>
     <h2 class="table_title">Current voting member projects</h2>
     <table>
         <tr>


### PR DESCRIPTION
Make href absolute (like others) so it correctly links to the bylaws page.