### PR TITLE
Correct name of IBM i Toolkit

### DIFF
--- a/pages/members.html
+++ b/pages/members.html
@@ -102,7 +102,7 @@ permalink: members/
             <td>Jan Schneider (<a href="https://twitter.com/yunosh">@yunosh</a>)</td>
         </tr>
         <tr>
-            <td><a target="_blank" href="https://github.com/zendtech/IbmiToolkit/">IBMi Toolkit</a></td>
+            <td><a target="_blank" href="https://github.com/zendtech/IbmiToolkit/">IBM i Toolkit</a></td>
             <td>Adam Culp (<a href="https://twitter.com/adamculp">@adamculp</a>)</td>
         </tr>
         <tr>


### PR DESCRIPTION
It's a common mistake to combine "IBM" and "i," but the appropriate spelling it "IBM i." See [IBM's web site](http://www-03.ibm.com/systems/power/software/i/).