### PR TITLE
Agavi left due to inactivity

### DIFF
--- a/pages/members.html
+++ b/pages/members.html
@@ -54,10 +54,6 @@ permalink: members/
             <th>Representative</th>
         </tr>
         <tr>
-            <td><a target="_blank" href="http://www.agavi.org/">Agavi</a></td>
-            <td>David Zülke (<a href="http://twitter.com/dzuelke/">@dzuelke</a>)</td>
-        </tr>
-        <tr>
             <td><a target="_blank" href="http://github.com/kriswallsmith/assetic/">Assetic</a> and <a target="_blank" href="https://github.com/kriswallsmith/Buzz">Buzz</a></td>
             <td>Kris Wallsmith (<a href="http://twitter.com/kriswallsmith/">@kriswallsmith</a>)</td>
         </tr>


### PR DESCRIPTION
[David Zuelke stepped down](https://groups.google.com/forum/#!topic/php-fig/okG4yJ93dDw), one of many inactive projects that will be getting out of the FIG to avoid votes stalling out due to lack of quorum.