### PR TITLE
Wrap feature links in <li> tags

### DIFF
--- a/_sass/blocks/home_features.scss
+++ b/_sass/blocks/home_features.scss
@@ -54,6 +54,10 @@
         margin: 15px 0 25px 0;
     }
 
+    li {
+        display: inline;
+    }
+
     &__link {
         display: inline-block;
         margin: 0 5px 5px 0;

--- a/pages/index.html
+++ b/pages/index.html
@@ -65,7 +65,7 @@ class ClassName
                     <h2 class="home_features__title">Autoloading</h2>
                     <p class="home_features__description">Autoloaders remove the complexity of including files by mapping namespaces to file system paths.</p>
                     <ul class="home_features__links">
-                        <a class="home_features__link" href="/psr/psr-4/">PSR-4: Improved Autoloading</a>
+                        <li><a class="home_features__link" href="/psr/psr-4/">PSR-4: Improved Autoloading</a></li>
                     </ul>
                 </div>
                 <div class="home_features__editor">
@@ -86,9 +86,9 @@ class ClassName
                     <h2 class="home_features__title">Interfaces</h2>
                     <p class="home_features__description">Interfaces simplify the sharing of code between projects by following expected contracts.</p>
                     <ul class="home_features__links">
-                        <a class="home_features__link" href="/psr/psr-3/">PSR-3: Logger Interface</a>
-                        <a class="home_features__link" href="/psr/psr-6/">PSR-6: Caching Interface</a>
-                        <a class="home_features__link" href="/psr/psr-7/">PSR-7: HTTP Message Interfaces</a>
+                        <li><a class="home_features__link" href="/psr/psr-3/">PSR-3: Logger Interface</a></li>
+                        <li><a class="home_features__link" href="/psr/psr-6/">PSR-6: Caching Interface</a></li>
+                        <li><a class="home_features__link" href="/psr/psr-7/">PSR-7: HTTP Message Interfaces</a></li>
                     </ul>
                 </div>
                 <div class="home_features__editor">
@@ -109,8 +109,8 @@ class ClassName
                     <h2 class="home_features__title">Coding Styles</h2>
                     <p class="home_features__description">Standardized formatting reduces the cognitive friction when reading code from other authors.</p>
                     <ul class="home_features__links">
-                        <a class="home_features__link" href="/psr/psr-1/">PSR-1: Basic Coding Standard</a>
-                        <a class="home_features__link" href="/psr/psr-2/">PSR-2: Coding Style Guide</a>
+                        <li><a class="home_features__link" href="/psr/psr-1/">PSR-1: Basic Coding Standard</a></li>
+                        <li><a class="home_features__link" href="/psr/psr-2/">PSR-2: Coding Style Guide</a></li>
                     </ul>
                 </div>
                 <div class="home_features__editor">


### PR DESCRIPTION
The `<a>` links need to be nested in `<li>`s in order to render valid
html.