### PR TITLE
Revert "Wrap feature links in <li> tags"

### DIFF
--- a/_sass/blocks/home_features.scss
+++ b/_sass/blocks/home_features.scss
@@ -54,10 +54,6 @@
         margin: 15px 0 25px 0;
     }
 
-    li {
-        display: inline;
-    }
-
     &__link {
         display: inline-block;
         margin: 0 5px 5px 0;

--- a/pages/index.html
+++ b/pages/index.html
@@ -65,7 +65,7 @@ class ClassName
                     <h2 class="home_features__title">Autoloading</h2>
                     <p class="home_features__description">Autoloaders remove the complexity of including files by mapping namespaces to file system paths.</p>
                     <ul class="home_features__links">
-                        <li><a class="home_features__link" href="/psr/psr-4/">PSR-4: Improved Autoloading</a></li>
+                        <a class="home_features__link" href="/psr/psr-4/">PSR-4: Improved Autoloading</a>
                     </ul>
                 </div>
                 <div class="home_features__editor">
@@ -86,9 +86,9 @@ class ClassName
                     <h2 class="home_features__title">Interfaces</h2>
                     <p class="home_features__description">Interfaces simplify the sharing of code between projects by following expected contracts.</p>
                     <ul class="home_features__links">
-                        <li><a class="home_features__link" href="/psr/psr-3/">PSR-3: Logger Interface</a></li>
-                        <li><a class="home_features__link" href="/psr/psr-6/">PSR-6: Caching Interface</a></li>
-                        <li><a class="home_features__link" href="/psr/psr-7/">PSR-7: HTTP Message Interfaces</a></li>
+                        <a class="home_features__link" href="/psr/psr-3/">PSR-3: Logger Interface</a>
+                        <a class="home_features__link" href="/psr/psr-6/">PSR-6: Caching Interface</a>
+                        <a class="home_features__link" href="/psr/psr-7/">PSR-7: HTTP Message Interfaces</a>
                     </ul>
                 </div>
                 <div class="home_features__editor">
@@ -109,8 +109,8 @@ class ClassName
                     <h2 class="home_features__title">Coding Styles</h2>
                     <p class="home_features__description">Standardized formatting reduces the cognitive friction when reading code from other authors.</p>
                     <ul class="home_features__links">
-                        <li><a class="home_features__link" href="/psr/psr-1/">PSR-1: Basic Coding Standard</a></li>
-                        <li><a class="home_features__link" href="/psr/psr-2/">PSR-2: Coding Style Guide</a></li>
+                        <a class="home_features__link" href="/psr/psr-1/">PSR-1: Basic Coding Standard</a>
+                        <a class="home_features__link" href="/psr/psr-2/">PSR-2: Coding Style Guide</a>
                     </ul>
                 </div>
                 <div class="home_features__editor">


### PR DESCRIPTION
Reverts php-fig/php-fig.github.com#217

Even though this was a good change, since the markup is wrong, it messed up the home page. I'll fix this properly when I have a chance. Until then, I'm going to revert this change.

![image](https://cloud.githubusercontent.com/assets/882133/22119906/53c45c42-de4b-11e6-9e89-53f7d3550147.png)
