### PR TITLE
Fix dev instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ If you want to develop in the Docker runtime, you'll have mount the project root
 
 ```bash
 docker build . --target dev -t fig-website-dev
-docker run --rm -ti -p 80:8000 -v $PWD:/fig-website fig-website-dev 
+docker run --rm -ti -p 8000:8000 -v $PWD:/fig-website fig-website-dev 
 # inside the container terminal
 install.sh
 build.sh


### PR DESCRIPTION
Sculpin by default exposes the served site on port 8000, not 80

```
$ sculpin serve
Starting Sculpin server for the dev environment with debug true
Development server is running at http://localhost:8000
Quit the server with CONTROL-C.
```